### PR TITLE
Add new required whitelisted_destinations param for telnyx

### DIFF
--- a/app/controller/setting.controller.js
+++ b/app/controller/setting.controller.js
@@ -242,6 +242,7 @@ exports.create = async (req, res) => {
                     "api/setting/receive-sms/",
                     req.body.type
                   ),
+                  whitelisted_destinations: ["*"]
                 });
                 var telnyxSetting = saveTelnyxSetting.data.id;
               } else {


### PR DESCRIPTION
Fixes #214

This is required due to https://telnyx.com/release-notes/security-updates-to-messaging-api-and-portal

I have not tested this fix yet, but followed the docs in https://developers.telnyx.com/api/messaging/create-messaging-profile

`whitelisted_destinations` is now a required field.

![image](https://github.com/0perationPrivacy/VoIP/assets/12688112/f2ae0006-eb56-42f3-b246-426aa8f5de5b)
